### PR TITLE
Add no-op compensating action

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ def orderSaga(): ZIO[Any with Clock, SagaError, Unit] = {
 - Compose sagas to run in parallel
 - Log sagas actions to database and restore in case of failure
 - Tests
+- Improve docs, show that it's not a simple task to compose sagas by your own

--- a/src/main/scala/scalaz/zio/saga/Saga.scala
+++ b/src/main/scala/scalaz/zio/saga/Saga.scala
@@ -3,23 +3,46 @@ import scalaz.zio.{ IO, Schedule, ZIO }
 import scalaz.zio.clock.Clock
 import scalaz.zio.saga.Saga.Compensator
 
+/**
+ * A Saga is an immutable structure that models a distributed transaction.
+ *
+ * @see [[https://medium.com/@tomasz_96685/saga-pattern-and-microservices-architecture-d4b46071afcf Saga pattern]]
+ *
+ * Saga class has two type parameters - E for errors and A for successful result.
+ * Saga wraps a ZIO that carries the compensating action in both error and result channels and enables a composition
+ * with another Sagas in for-comprehensions.
+ * If error occurs Saga will execute compensating actions starting from action that corresponds to failed request
+ * till the first already completed request.
+ * */
 final case class Saga[+E, +A] private (
   private val request: ZIO[Any with Clock, (E, Compensator[Any, E]), (A, Compensator[Any, E])]
 ) extends AnyVal {
   self =>
 
+  /**
+   * Maps the resulting value `A` of this saga to value `B` with function `f`.
+   * */
   def map[B](f: A => B): Saga[E, B] =
     Saga(request.map { case (a, comp) => (f(a), comp) })
 
+  /**
+   * Sequences the result of this saga to the next saga.
+   * */
   def flatMap[E1 >: E, B](f: A => Saga[E1, B]): Saga[E1, B] =
     Saga(request.flatMap {
       case (a, compA) =>
         tapError(f(a).request)({ case (e, _) => compA.mapError(_ => (e, IO.unit)) })
     })
 
+  /**
+   * Flattens the structure of this saga by executing outer saga first and then executes inner saga.
+   * */
   def flatten[E1 >: E, B](implicit ev: A <:< Saga[E1, B]): Saga[E1, B] =
     self.flatMap(r => ev(r))
 
+  /**
+   * Materializes this saga to ZIO effect.
+   * */
   def run: ZIO[Any with Clock, E, A] =
     tapError(request)({ case (e, compC) => compC.mapError(_ => (e, IO.unit)) }).bimap(_._1, _._1)
 
@@ -35,24 +58,37 @@ object Saga {
 
   type Compensator[-R, +E] = ZIO[R with Clock, E, Unit]
 
-  def compensate[R >: Any, E, A](action: IO[E, A], c: Compensator[R, E]): Saga[E, A] =
-    Saga(action.bimap((_, c), (_, c)))
+  /**
+   * Constructs new Saga from action and compensating action.
+   * */
+  def compensate[R >: Any, E, A](request: IO[E, A], compensator: Compensator[R, E]): Saga[E, A] =
+    Saga(request.bimap((_, compensator), (_, compensator)))
 
-  def retryableCompensate[R >: Any, E, A](action: IO[E, A],
-                                          c: Compensator[R, E],
-                                          schedule: Schedule[E, Any]): Saga[E, A] = {
-    compensate(action, c.retry(schedule.unit))
-  }
+  /**
+   * Constructs new Saga from action, compensating action and a scheduling policy for retrying compensation.
+   * */
+  def retryableCompensate[R >: Any, E, A](
+    request: IO[E, A],
+    compensator: Compensator[R, E],
+    schedule: Schedule[E, Any]
+  ): Saga[E, A] =
+    compensate(request, compensator.retry(schedule.unit))
 
-  def noCompensate[E, A](action: IO[E, A]): Saga[E, A] = compensate(action, ZIO.unit)
+  /**
+   * Constructs new `no-op` saga that will do nothing on error.
+   * */
+  def noCompensate[E, A](request: IO[E, A]): Saga[E, A] = compensate(request, ZIO.unit)
 
-  implicit class Compensable[+E, +A](val action: IO[E, A]) extends AnyVal {
-    def compensate[R >: Any, E1 >: E](c: Compensator[R, E1]): Saga[E1, A] = Saga.compensate(action, c)
+  /**
+   * Extension methods for IO requests.
+   * */
+  implicit class Compensable[+E, +A](val request: IO[E, A]) extends AnyVal {
+    def compensate[R >: Any, E1 >: E](c: Compensator[R, E1]): Saga[E1, A] = Saga.compensate(request, c)
 
     def retryableCompensate[R >: Any, E1 >: E](c: Compensator[R, E1], schedule: Schedule[E1, Any]): Saga[E1, A] =
-      Saga.retryableCompensate(action, c, schedule)
+      Saga.retryableCompensate(request, c, schedule)
 
-    def noCompensate: Saga[E, A] = Saga.noCompensate(action)
+    def noCompensate: Saga[E, A] = Saga.noCompensate(request)
   }
 
 }

--- a/src/main/scala/scalaz/zio/saga/Saga.scala
+++ b/src/main/scala/scalaz/zio/saga/Saga.scala
@@ -8,10 +8,10 @@ final case class Saga[+E, +A] private (
 ) extends AnyVal {
   self =>
 
-  def map[C](f: A => C): Saga[E, C] =
+  def map[B](f: A => B): Saga[E, B] =
     Saga(request.map { case (a, comp) => (f(a), comp) })
 
-  def flatMap[E1 >: E, C](f: A => Saga[E1, C]): Saga[E1, C] =
+  def flatMap[E1 >: E, B](f: A => Saga[E1, B]): Saga[E1, B] =
     Saga(request.flatMap {
       case (a, compA) =>
         tapError(f(a).request)({ case (e, _) => compA.mapError(_ => (e, IO.unit)) })


### PR DESCRIPTION
Allows you to write ```someRequestIO.noCompensate``` and get a saga request that has no compensating action